### PR TITLE
[#2795]Fixed the issue that the dynamic modification configuration of gray release is invalid.

### DIFF
--- a/governance/src/main/java/org/apache/servicecomb/router/cache/RouterRuleCache.java
+++ b/governance/src/main/java/org/apache/servicecomb/router/cache/RouterRuleCache.java
@@ -49,20 +49,17 @@ public class RouterRuleCache {
 
   private Environment environment;
 
-  @Autowired
-  public RouterRuleCache(Environment environment) {
-    this.environment = environment;
-  }
-
   private final ConcurrentHashMap<String, ServiceInfoCache> serviceInfoCacheMap = new ConcurrentHashMap<>();
 
   private final Object lock = new Object();
 
   private final Representer representer = new Representer();
 
-  public RouterRuleCache() {
+  @Autowired
+  public RouterRuleCache(Environment environment) {
     representer.getPropertyUtils().setSkipMissingProperties(true);
     GovernanceEventManager.register(this);
+    this.environment = environment;
   }
 
   /**


### PR DESCRIPTION
The new constructor makes the original constructor invalid.Combine the two constructors so that the class is loaded correctly.
